### PR TITLE
Extends the test to demostrate issue #1

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -5,3 +5,7 @@ print(
   random ===
   require('./ran/dom')
 );
+
+const sin = require('./recursive/sin');
+print('Exported recursive.sin:' + sin);
+print('recursive.sin() result: ' + sin());

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ print(
   require('./ran/dom')
 );
 
-const sin = require('./recursive/sin');
-print('Exported recursive.sin:' + sin);
-print('recursive.sin() result: ' + sin());
+print('Recursion test');
+const {rand_sin} = require('./recursive/sin');
+print('Imported recursive.rand_sin:' + rand_sin);
+print('recursive.rand_sin() result: ' + rand_sin());

--- a/test/recursive/random.js
+++ b/test/recursive/random.js
@@ -1,0 +1,2 @@
+print(__filename);
+module.exports = Math.random();

--- a/test/recursive/sin.js
+++ b/test/recursive/sin.js
@@ -1,3 +1,4 @@
 print(__filename);
-const {random} = require('../ran/dom');
-exports.rand_sin = () => { return Math.sin(random()) };
+const random = require('./random');
+print('Imported random: ' + random);
+exports.rand_sin = () => { return Math.sin(random); };

--- a/test/recursive/sin.js
+++ b/test/recursive/sin.js
@@ -1,0 +1,3 @@
+print(__filename);
+const {random} = require('../ran/dom');
+exports.rand_sin = () => { return Math.sin(random()) };


### PR DESCRIPTION
The new test includes a new file `recursive/random.js`. This is identical to `ran/dom.js` but I could not reuse that from the same `index.js` because the second time it was imported `require` would return the cached version and not trigger the bug.

Typescript sets exports by adding properties to the global `exports` variable, so I did the same in the new test. I think if I used the same technique as the original test (replacing `module.exports`), that would also have failed to trigger the bug. 